### PR TITLE
"dot".unixCmd fix

### DIFF
--- a/Classes/ClassExtensions/extClass-makeUML.sc
+++ b/Classes/ClassExtensions/extClass-makeUML.sc
@@ -88,7 +88,7 @@
 
     prCompileDotfile{arg dotfilePath, openWhenDone;
         var result;
-		"/usr/local/bin/dot % -Tpdf -O".format(dotfilePath).unixCmd({arg returnCode ...args;
+		"dot % -Tpdf -O".format(dotfilePath).unixCmd({arg returnCode ...args;
 			var imgPath;
 			if(returnCode != 0, {
 				"Error running 'dot' program".warn;


### PR DESCRIPTION
Hi @blacksound,
I propose to pull this.
Remove ' /usr/local/bin/ ' from `dot` command.
because dot is not necessarily installed in ' /usr/local/bin '.
User should instead make sure `dot` is in system's `$PATH`
